### PR TITLE
fix: Footer not staying at bottom of the page

### DIFF
--- a/src/pages/files/index.tsx
+++ b/src/pages/files/index.tsx
@@ -20,7 +20,13 @@ export default function FilePage() {
       />
       <Header />
       <main className="relative w-full h-auto">
-        <div className="mx-auto py-10 px-6 max-w-[1440px] w-full">
+        <div
+          className={`mx-auto py-10 px-6 max-w-[1440px] w-full h-full ${
+            process.env.NODE_ENV === "development"
+              ? "min-h-[calc(100vh-162px)]"
+              : "min-h-[calc(100vh-122px)]"
+          }`}
+        >
           <div className="flex flex-row items-center justify-between w-full">
             <CreateReadmeFileButton />
           </div>


### PR DESCRIPTION
Closes #4 - Fix the issue of the Footer not staying at the bottom of the 'files' page.

Screen-shot

Issue:

![issue](https://user-images.githubusercontent.com/94737463/219608731-51a55926-4fb0-4fd1-9e63-ac38140059bc.png)

Solved: 

![solved](https://user-images.githubusercontent.com/94737463/219608786-5ef3d477-e09c-4b19-a8f2-f0ebf63630f8.png)
