### PR TITLE
Fix: Footer not staying at the bottom of the page

### DIFF
--- a/src/pages/files/index.tsx
+++ b/src/pages/files/index.tsx
@@ -20,7 +20,13 @@ export default function FilePage() {
       />
       <Header />
       <main className="relative w-full h-auto">
-        <div className="mx-auto py-10 px-6 max-w-[1440px] w-full">
+        <div
+          className={`mx-auto py-10 px-6 max-w-[1440px] w-full h-full ${
+            process.env.NODE_ENV === "development"
+              ? "min-h-[calc(100vh-162px)]"
+              : "min-h-[calc(100vh-122px)]"
+          }`}
+        >
           <div className="flex flex-row items-center justify-between w-full">
             <CreateReadmeFileButton />
           </div>


### PR DESCRIPTION
## Description

The issue of the footer not staying at the bottom of the page is a common problem encountered in web design. This occurs when there is not enough content on the page to push the footer down to the bottom, leaving an awkward gap between the content and the footer. To fix this issue, set a fixed minimum height for the main container.

## Bug Fixes

- #4 