### PR TITLE
[FIX] - Corrected the run command from "npm run start" to "npm run dev"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 **ReadmeEase** is a cutting-edge platform designed to simplify the creation of high-quality README files. With its user-friendly drag and drop interface, users can easily design and customize their README files with ease. The platform is built using Next.js and Tailwind CSS, offering a fast, responsive, and visually appealing experience. Whether you're a developer, designer, or documentarian, ReadmeEase is the perfect solution for creating professional README files with ease
 
-
 ## Run Locally
 
 1. Click on the [Fork](https://github.com/JunDevHarsh/ReadmeEase/fork) button at the top right corner of the repository page to create a copy of the project on your GitHub account.
@@ -30,7 +29,7 @@
 5. Start the server
 
    ```bash
-   npm run start
+   npm run dev
    ```
 
 ## Tech Stack


### PR DESCRIPTION
## Description

The current **README.md** file states to run the command `npm run start` to start the project, but it should be `npm run dev`. This pull request updates the **README.md** file with the corrected command to run the project.

## Bug Fixes

#7 - [[DOCS] - Write 'npm run dev' instead of 'npm run start'](https://github.com/JunDevHarsh/ReadmeEase/issues/7)